### PR TITLE
Add additional directories feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ BepInEx 5.3 or newer
    baseDir = <FULL PATH TO THE MODS FOLDER>
    disabledModsListPath = <OPTIONAL FULL PATH TO MODS IGNORE FILE>
    enabledModsListPath = <OPTIONAL FULL PATH TO MODS IGNORE FILE>
+   enableAdditionalDirectories = <OPTIONAL SET TO "TRUE" TO ENABLE ADDITIONAL DIRS>
    ```
    
    where you specify the full path to the folder that will work as mod base.
@@ -69,3 +70,7 @@ Notes:
 ## Enabling mods explicitly
 
 Alternatively, you can define a list of folders to explicitly load. The file format is the same as for [skipping mods](#skipping-mods-explicitly), but instead define `enabledModsListPath` config value.
+
+## Additional directories
+
+If you want to load mods from more than one directory, you may set `enableAdditionalDirectories` config value to `true`, and define additional directories in sections `[MultiFolderLoader_<NAME>]`. Format is the same as for [original directory](#Installation), except that `enableAdditionalDirectories` wouldn't have additional effect.


### PR DESCRIPTION
Add feature that allows to load mods from different directories.

Right now MFL can only load from one directory, which may not be enough for usage

INI format doesn't allow any lists, and only symbol that can consistently be used as separator of different paths is NULL which usage in config is not desireable, so decision was made to use sections as a surrogate for lists. Additional directories have format of `MultiFolderLoader_<NAME>`, and are only loaded if additional sections are enabled from main section.